### PR TITLE
Add workspace setup script

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SOURCE_REPO="$HOME/repos/portfolio"
+
+echo "Setting up workspace at $REPO_ROOT"
+
+# Copy environment files from source repo
+if [ -f "$SOURCE_REPO/.env.local" ]; then
+  cp "$SOURCE_REPO/.env.local" "$REPO_ROOT/.env.local"
+  echo "Copied .env.local"
+else
+  echo "Warning: $SOURCE_REPO/.env.local not found, skipping"
+fi
+
+if [ -f "$SOURCE_REPO/packages/db/.env" ]; then
+  cp "$SOURCE_REPO/packages/db/.env" "$REPO_ROOT/packages/db/.env"
+  echo "Copied packages/db/.env"
+else
+  echo "Warning: $SOURCE_REPO/packages/db/.env not found, skipping"
+fi
+
+# Install dependencies
+cd "$REPO_ROOT"
+pnpm install
+
+echo "Setup complete"


### PR DESCRIPTION
## Summary
- Adds `scripts/setup.sh` that copies `.env.local` and `packages/db/.env` from `~/repos/portfolio` into the workspace, then runs `pnpm install`

## Test plan
- [x] Ran script locally — env files copied, dependencies installed, Prisma client generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)