### PR TITLE
Add .worktreeinclude for git worktree configuration

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,4 @@
+.env
+.env.local
+.env.*
+**/.claude/settings.local.json


### PR DESCRIPTION
Add `.worktreeinclude` file to configure which files should persist across git worktrees. This ensures that `.env` files and local settings are not managed by git worktree isolation, allowing them to be shared or maintained independently across worktrees.

🤖 Generated with Claude Code